### PR TITLE
fix: remove fastify-plugin wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/healthcheck",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Standardized web server health checks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.25.24",
-    "fastify": "^4.2.1",
-    "fastify-plugin": "^4.0.0"
+    "fastify": "^4.2.1"
   },
   "optionalDependencies": {
     "node-fetch": "2"

--- a/src/plugins/fastify.ts
+++ b/src/plugins/fastify.ts
@@ -1,5 +1,4 @@
 import type { FastifyPluginCallback, FastifyReply, FastifyRequest, HTTPMethods } from 'fastify'
-import fp from 'fastify-plugin'
 import type { HealthCheck } from '../healthcheck'
 
 export interface FastifyRfcHealthCheckOptions {
@@ -9,7 +8,7 @@ export interface FastifyRfcHealthCheckOptions {
   healthCheck: HealthCheck<[FastifyRequest?]>
 }
 
-const plugin: FastifyPluginCallback<FastifyRfcHealthCheckOptions> = (fastify, options, done) => {
+export const healthCheckFastify: FastifyPluginCallback<FastifyRfcHealthCheckOptions> = (fastify, options, done) => {
   const url = options?.path ?? '/health'
   const method = options?.method ?? 'GET'
   const cacheControl = Object.entries(options?.cacheControl ?? { 'max-age': '3600' })
@@ -28,8 +27,3 @@ const plugin: FastifyPluginCallback<FastifyRfcHealthCheckOptions> = (fastify, op
   fastify.route({ method, url, handler })
   done()
 }
-
-export const healthCheckFastify = fp(plugin, {
-  fastify: '>=3',
-  name: '@byu-oit/healthcheck'
-})


### PR DESCRIPTION
This wrapper was causing the logLevel option to not be used which made healthcheck logs all too visible. I was working on [ENG019878](https://support.byu.edu/u_eng_task.do?sys_id=9ea70ece1b283d500123ea43604bcbee&sysparm_view=&sysparm_time=1692057066065) which is a task to remove the unnecessary /health endpoint logs cluttering up cloudwatch. In the AMPS code I found that we were already setting the logLevel to 'error' for  the healthcheck plugin which should have blocked all of the info-level logs that we were  seeing. Then I found [this part](https://fastify.dev/docs/latest/Reference/Plugins/#plugin-options) in the documentation that says:
> The optional options parameter for fastify.register supports a predefined set of options that Fastify itself will use, except when the plugin has been wrapped with [fastify-plugin](https://github.com/fastify/fastify-plugin). This options object will also be passed to the plugin upon invocation, regardless of whether or not the plugin has been wrapped. The currently supported list of Fastify specific options is:
>
>  - logLevel
>  - logSerializers
>  - prefix
>
> Note: Those options will be ignored when used with fastify-plugin

@stuft2 [decided](https://teams.microsoft.com/l/message/19:935c99b711884d148d4f170ff0daf20d@thread.tacv2/1692142445716?tenantId=c6fc6e9b-51fb-48a8-b779-9ee564b40413&groupId=99f0115e-72e8-4ad5-91e4-c7082afba8a9&parentMessageId=1692137117063&teamName=Application%20Engineering&channelName=SpecOps%20-%20Developer&createdTime=1692142445716&allowXTenantAccess=false) that it would be best to remove the fastify-plugin wrapper since it was doing more harm than good.